### PR TITLE
Reset Button in Settings

### DIFF
--- a/ChecklistApp/ChecklistStore.swift
+++ b/ChecklistApp/ChecklistStore.swift
@@ -1,0 +1,44 @@
+//
+//  ChecklistStore.swift
+//  ChecklistApp
+//
+//  Created by Marc Pinder on 06/06/2025.
+//
+
+
+import Foundation
+import SwiftUI
+
+class ChecklistStore: ObservableObject {
+    @Published var checklists: [Checklist] = []
+    
+    private let checklistsKey = "SavedChecklists"
+    
+    init() {
+        load()
+    }
+    
+    func load() {
+        if let savedData = UserDefaults.standard.data(forKey: checklistsKey),
+           let decoded = try? JSONDecoder().decode([Checklist].self, from: savedData) {
+            checklists = decoded
+        }
+    }
+    
+    func save() {
+        if let encoded = try? JSONEncoder().encode(checklists) {
+            UserDefaults.standard.set(encoded, forKey: checklistsKey)
+        }
+    }
+    
+    func reset() {
+        checklists.removeAll()
+        UserDefaults.standard.removeObject(forKey: checklistsKey)
+        save() // ensures observers see the update
+    }
+
+    func add(_ checklist: Checklist) {
+        checklists.append(checklist)
+        save()
+    }
+}

--- a/ChecklistApp/ContentView.swift
+++ b/ChecklistApp/ContentView.swift
@@ -8,12 +8,16 @@
 import SwiftUI
 
 struct ContentView: View {
+
+    @StateObject private var store = ChecklistStore()
+
     var body: some View {
         TabView {
             MyListsView()
                 .tabItem {
                     Label("My Lists", systemImage: "checklist")
                 }
+                .environmentObject(store)
             
             SearchView()
                 .tabItem {
@@ -29,6 +33,7 @@ struct ContentView: View {
                 .tabItem {
                     Label("Settings", systemImage: "gearshape")
                 }
+                .environmentObject(store)
         }
     }
 }

--- a/ChecklistApp/MyListsView.swift
+++ b/ChecklistApp/MyListsView.swift
@@ -8,16 +8,13 @@
 import SwiftUI
 
 struct MyListsView: View {
-    
     @State private var showingCreateList = false
-    @State private var checklists: [Checklist] = []
-    
-    private let checklistsKey = "SavedChecklists"
-    
+    @EnvironmentObject var store: ChecklistStore
+
     var body: some View {
         NavigationView {
             VStack {
-                if checklists.isEmpty {
+                if store.checklists.isEmpty {
                     Text("No lists yet!")
                         .font(.headline)
                         .foregroundColor(.gray)
@@ -25,7 +22,7 @@ struct MyListsView: View {
                     Spacer()
                 } else {
                     List {
-                        ForEach($checklists) { $checklist in
+                        ForEach($store.checklists) { $checklist in
                             NavigationLink(destination: ChecklistDetailView(checklist: $checklist)) {
                                 Text(checklist.title)
                             }
@@ -39,28 +36,9 @@ struct MyListsView: View {
             })
             .sheet(isPresented: $showingCreateList) {
                 CreateListView { newChecklist in
-                    checklists.append(newChecklist)
-                    saveChecklists()
+                    store.add(newChecklist)
                 }
             }
-            .onAppear {
-                loadChecklists()
-            }
-        }
-    }
-    
-    // MARK: - Persistence
-    
-    private func saveChecklists() {
-        if let encoded = try? JSONEncoder().encode(checklists) {
-            UserDefaults.standard.set(encoded, forKey: checklistsKey)
-        }
-    }
-
-    private func loadChecklists() {
-        if let savedData = UserDefaults.standard.data(forKey: checklistsKey),
-           let decoded = try? JSONDecoder().decode([Checklist].self, from: savedData) {
-            checklists = decoded
         }
     }
 }

--- a/ChecklistApp/SettingsView.swift
+++ b/ChecklistApp/SettingsView.swift
@@ -8,8 +8,26 @@
 import SwiftUI
 
 struct SettingsView: View {
+
+    @State var showResetConfirmation: Bool = false
+    @EnvironmentObject var store: ChecklistStore
+
     var body: some View {
-        Text("This is the settings page")
+        NavigationView {
+            List {
+                Section("Reset") {
+                    Button("Reset Checklists") {
+                        showResetConfirmation = true
+                    }
+                    .alert(isPresented: $showResetConfirmation) {
+                        Alert(title: Text("Are you sure?"), message: Text("This will remove all your checklists and items."), primaryButton: .destructive(Text("Reset"), action: {
+                            store.reset()
+                        }), secondaryButton: .cancel())
+                    }
+                }
+            }
+            .navigationTitle(Text("Settings"))
+        }
     }
 }
 


### PR DESCRIPTION
As well as the reset button i've also moved 'up' the management of the checklists to a separate class so it can be referenced from anywhere, and passed this 'in' to the sub-views via the environment. This way, any screen can reference it. We'll probably need to reference it for the search tab.